### PR TITLE
Failure Callback

### DIFF
--- a/www/cdv-plugin-card-io.js
+++ b/www/cdv-plugin-card-io.js
@@ -43,6 +43,7 @@ CardIO.prototype.scan = function(options, onSuccess, onFailure) {
 CardIO.prototype.canScan = function(callback) {
   var failureCallback = function() {
     console.log("Could not detect whether card.io card scanning is available.");
+    callback(false);
   };
   var wrappedSuccess = function(response) {
     callback(response !== 0);


### PR DESCRIPTION
Call the canscan callback with false as the result in case cordova exec results in failure callback.

In case of some android phones failureCallback gets called inside the plugin, but there's no callback to let the host app know.  

