### PR TITLE
Check Android M permissions before open the CardIoActivity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,6 +12,7 @@
             <engine name="cordova" version="&gt;=3.0.0" />
     </engines>
 
+    <dependency id="cordova-plugin-compat" version="^1.0.0" />
 
     <js-module src="www/cdv-plugin-card-io.js" name="CardIO">
         <clobbers target="CardIO" />


### PR DESCRIPTION
From Android M and after, we need to ask the user for permissions to use some device capabilities.
With the `cordova-plugin-compat` plugin we can check permissions on plugins easily.
So, we are adding support to check if you can use the camera.
Thanks!