### PR TITLE
Android: Fix guideColor config, fix return of card scan results succe…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -69,7 +69,25 @@
         </config-file>
 
         <source-file src="src/android/CardIOCordovaPlugin.java" target-dir="src/io/card/cordova/sdk" />
-	      <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+
+        <config-file parent="/*" target="AndroidManifest.xml">
+            <!-- Permission to vibrate - recommended, allows vibration feedback on scan -->
+            <uses-permission android:name="android.permission.VIBRATE" />
+
+            <!-- Permission to use camera - required -->
+            <uses-permission android:name="android.permission.CAMERA" />
+
+            <!-- Camera features - recommended -->
+            <uses-feature android:name="android.hardware.camera" android:required="false" />
+            <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+            <uses-feature android:name="android.hardware.camera.flash" android:required="false" />
+        </config-file>
+
+        <config-file parent="/manifest/application" target="AndroidManifest.xml">
+            <activity android:name="io.card.payment.CardIOActivity" android:configChanges="keyboardHidden|orientation" />
+            <activity android:name="io.card.payment.DataEntryActivity" />
+        </config-file>
 
     </platform>
 

--- a/src/android/CardIOCordovaPlugin.java
+++ b/src/android/CardIOCordovaPlugin.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.graphics.Color;
 
 import io.card.payment.CardIOActivity;
 import io.card.payment.CreditCard;
@@ -70,11 +71,20 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
         scanIntent.putExtra(CardIOActivity.EXTRA_NO_CAMERA, this.getConfiguration(configurations, "noCamera", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SCAN_EXPIRY, this.getConfiguration(configurations, "scanExpiry", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_LANGUAGE_OR_LOCALE, this.getConfiguration(configurations, "languageOrLocale", false)); // default: false
-        scanIntent.putExtra(CardIOActivity.EXTRA_GUIDE_COLOR, this.getConfiguration(configurations, "guideColor", false)); // default: false
+        scanIntent.putExtra(CardIOActivity.EXTRA_GUIDE_COLOR, loadGuideColor(configurations)); // default: Color.GREEN
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION, this.getConfiguration(configurations, "suppressConfirmation", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, this.getConfiguration(configurations, "hideCardIOLogo", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_SCAN, this.getConfiguration(configurations, "suppressScan", false)); // default: false
         this.cordova.startActivityForResult(this, scanIntent, REQUEST_CARD_SCAN);
+    }
+
+    private int loadGuideColor(JSONObject configurations) {
+        String guideColorStr = this.getConfiguration(configurations, "guideColor", null);
+        if (guideColorStr != null) {
+            return Color.parseColor(guideColorStr);
+        }
+
+        return Color.GREEN;
     }
 
     private void canScan(JSONArray args) throws JSONException {
@@ -87,22 +97,21 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
     }
 
     // onActivityResult
+    @Override
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);
+
         if (REQUEST_CARD_SCAN == requestCode) {
-            if (resultCode == CardIOActivity.RESULT_CARD_INFO) {
-                CreditCard scanResult = null;
-                if (intent.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
-                    scanResult = intent
-                            .getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
-                    this.callbackContext.success(this.toJSONObject(scanResult));
-                } else {
-                    this.callbackContext
-                            .error("card was scanned but no result");
-                }
-            } else if (resultCode == Activity.RESULT_CANCELED) {
+            if (resultCode == Activity.RESULT_CANCELED) {
                 this.callbackContext.error("card scan cancelled");
+                return;
+            }
+
+            if (intent.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
+                CreditCard scanResult = intent.getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
+                this.callbackContext.success(this.toJSONObject(scanResult));
             } else {
-                this.callbackContext.error(resultCode);
+                this.callbackContext.error("card was scanned but no result");
             }
         }
     }


### PR DESCRIPTION
…ssfully, add permissions and activities for plugin

Fix guideColor config
* Abstract logic for ensuring hex color string returns as int
* Default to Color.GREEN if none given

Fix return of card scan results successfully
* Check if camera scan is canceled first then check card scan results

Add permissions and activities for plugin
* Add android permissions for VIBRATE and CAMERA
* Add uses-features for camera hardware
* Add activity for the io.card.payment.CardIOActivity and io.card.payment.DataEntryActivity classes