### PR TITLE
iOS: suppressConfirmation fixed; Android: fix misspelling for suppressManual

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The card.io Cordova plugin provides different configurations that could be set a
 |  requireExpiry                   | Boolean  | Expiry information will not be required. |
 |  requireCVV                      | Boolean  | The user will be prompted for the card CVV |
 |  requirePostalCode               | Boolean  | The user will be prompted for the card billing postal code. |
-|  supressManual                   | Boolean  | Removes the keyboard button from the scan screen. |
+|  suppressManual                  | Boolean  | Removes the keyboard button from the scan screen. |
 |  restrictPostalCodeToNumericOnly | Boolean  | The postal code will only collect numeric input. Set this if you know the expected country's postal code has only numeric postal codes. |
 |  keepApplicationTheme            | Boolean  | The theme for the card.io Activity's will be set to the theme of the application. |
 |  requireCardholderName           | Boolean  | The user will be prompted for the cardholder name |

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,7 +69,25 @@
         </config-file>
 
         <source-file src="src/android/CardIOCordovaPlugin.java" target-dir="src/io/card/cordova/sdk" />
-	      <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+
+        <config-file parent="/*" target="AndroidManifest.xml">
+            <!-- Permission to vibrate - recommended, allows vibration feedback on scan -->
+            <uses-permission android:name="android.permission.VIBRATE" />
+
+            <!-- Permission to use camera - required -->
+            <uses-permission android:name="android.permission.CAMERA" />
+
+            <!-- Camera features - recommended -->
+            <uses-feature android:name="android.hardware.camera" android:required="false" />
+            <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+            <uses-feature android:name="android.hardware.camera.flash" android:required="false" />
+        </config-file>
+
+        <config-file parent="/manifest/application" target="AndroidManifest.xml">
+            <activity android:name="io.card.payment.CardIOActivity" android:configChanges="keyboardHidden|orientation" />
+            <activity android:name="io.card.payment.DataEntryActivity" />
+        </config-file>
 
     </platform>
 

--- a/src/android/CardIOCordovaPlugin.java
+++ b/src/android/CardIOCordovaPlugin.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.graphics.Color;
 
 import io.card.payment.CardIOActivity;
 import io.card.payment.CreditCard;
@@ -70,11 +71,20 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
         scanIntent.putExtra(CardIOActivity.EXTRA_NO_CAMERA, this.getConfiguration(configurations, "noCamera", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SCAN_EXPIRY, this.getConfiguration(configurations, "scanExpiry", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_LANGUAGE_OR_LOCALE, this.getConfiguration(configurations, "languageOrLocale", false)); // default: false
-        scanIntent.putExtra(CardIOActivity.EXTRA_GUIDE_COLOR, this.getConfiguration(configurations, "guideColor", false)); // default: false
+        scanIntent.putExtra(CardIOActivity.EXTRA_GUIDE_COLOR, loadGuideColor(configurations)); // default: Color.GREEN
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION, this.getConfiguration(configurations, "suppressConfirmation", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, this.getConfiguration(configurations, "hideCardIOLogo", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_SCAN, this.getConfiguration(configurations, "suppressScan", false)); // default: false
         this.cordova.startActivityForResult(this, scanIntent, REQUEST_CARD_SCAN);
+    }
+
+    private int loadGuideColor(JSONObject configurations) {
+        String guideColorStr = this.getConfiguration(configurations, "guideColor", null);
+        if (guideColorStr != null) {
+            return Color.parseColor(guideColorStr);
+        }
+
+        return Color.GREEN;
     }
 
     private void canScan(JSONArray args) throws JSONException {
@@ -87,22 +97,21 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
     }
 
     // onActivityResult
+    @Override
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);
+
         if (REQUEST_CARD_SCAN == requestCode) {
-            if (resultCode == CardIOActivity.RESULT_CARD_INFO) {
-                CreditCard scanResult = null;
-                if (intent.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
-                    scanResult = intent
-                            .getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
-                    this.callbackContext.success(this.toJSONObject(scanResult));
-                } else {
-                    this.callbackContext
-                            .error("card was scanned but no result");
-                }
-            } else if (resultCode == Activity.RESULT_CANCELED) {
+            if (resultCode == Activity.RESULT_CANCELED) {
                 this.callbackContext.error("card scan cancelled");
+                return;
+            }
+
+            if (intent.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
+                CreditCard scanResult = intent.getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
+                this.callbackContext.success(this.toJSONObject(scanResult));
             } else {
-                this.callbackContext.error(resultCode);
+                this.callbackContext.error("card was scanned but no result");
             }
         }
     }

--- a/src/android/CardIOCordovaPlugin.java
+++ b/src/android/CardIOCordovaPlugin.java
@@ -62,7 +62,7 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_EXPIRY, this.getConfiguration(configurations, "requireExpiry", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_CVV, this.getConfiguration(configurations, "requireCVV", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_POSTAL_CODE, this.getConfiguration(configurations, "requirePostalCode", false)); // default: false
-        scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_MANUAL_ENTRY, this.getConfiguration(configurations, "supressManual", false)); // default: false
+        scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_MANUAL_ENTRY, this.getConfiguration(configurations, "suppressManual", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_RESTRICT_POSTAL_CODE_TO_NUMERIC_ONLY, this.getConfiguration(configurations, "restrictPostalCodeToNumericOnly", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_KEEP_APPLICATION_THEME, this.getConfiguration(configurations, "keepApplicationTheme", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_CARDHOLDER_NAME, this.getConfiguration(configurations, "requireCardholderName", false)); // default: false

--- a/src/ios/CardIOCordovaPlugin.m
+++ b/src/ios/CardIOCordovaPlugin.m
@@ -82,12 +82,12 @@
         paymentViewController.hideCardIOLogo = [hideCardIOLogo boolValue];
     }
 
-    NSNumber *suppressScanConfirmation = [options objectForKey:@"suppressScan"];
+    NSNumber *suppressScanConfirmation = [options objectForKey:@"suppressConfirmation"];
     if (suppressScanConfirmation) {
         paymentViewController.suppressScanConfirmation = [suppressScanConfirmation boolValue];
     }
 
-    NSNumber *disableManualEntryButtons = [options objectForKey:@"supressManual"];
+    NSNumber *disableManualEntryButtons = [options objectForKey:@"suppressManual"];
     if (disableManualEntryButtons) {
         paymentViewController.disableManualEntryButtons = [disableManualEntryButtons boolValue];
     }


### PR DESCRIPTION
* Fix iOS suppressConfirmation config variable name, which now enables this config for iOS
* Fix suppressManual misspelling for Android and README.md

This pull request also incorporates #44 .